### PR TITLE
Issue/#2

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 import uvicorn
 from fastapi import FastAPI, Request, Response, BackgroundTasks
 from linebot import WebhookParser, exceptions
-from linebot.models import TextMessage
+from linebot.models import TextMessage, events
 from aiolinebot import AioLineBotApi
 
 # get token and secret from os environment
@@ -31,11 +31,12 @@ def main():
 
 # body of echo
 async def echo_body(event) -> None:
-    await line_api.reply_message_async(
-        event.reply_token,
-        TextMessage(text=f"{event.message.text}")
-    )
-    pass
+    if isinstance(event.message, events.TextMessage):
+        await line_api.reply_message_async(
+            event.reply_token,
+            TextMessage(text=f"{event.message.text}")
+        )
+    
 
 @app.post("/messaging_api/echo")
 async def echo(


### PR DESCRIPTION
# 作業内容

- オウム返しをする機能を実装。

# 動作確認時の作業

- 以下の項目を環境変数に追加して下さい。
  - `POETRY_COVID19_REMINDER_LINE_BOT_TOKEN` : LINE BOTの長期トークン
  - `POETRY_COVID19_REMINDER_LINE_CHANNEL_SECRET` : LINE BOTのチャンネルシークレット

# Pull Request 再発行の理由

- 文字列以外のメッセージを受け取った際にエラーを生じるバグの修正のため。

## 補足

- ngrok を使用して動作確認を行いました。
- `line_api.reply_message_async` が `throw` する可能性のある `Exception` を把握できなかったので、そこだけエラー処理がありません。
- 以下のコミットは `Rebase` 打ちまくっても何故かメッセージに `(#2)` を付けられなかったので、多分ありません。
  - 1572d841124b064ef31cea20bc06ec3c18d9962a
  - 9365c737698e73c69b2fd351e874837e5bbbe94d
- `WebhookParser` がエラーを吐いた時は暫定で `HTTP 503 Error` にしてます

### その他

いや、ムズすぎない？