### PR TITLE
Issue/#2

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,15 +24,15 @@ line_api = AioLineBotApi(channel_access_token=LINE_TOKEN)
 parser = WebhookParser(channel_secret=LINE_SECRET)
 
 # definite peculiar types
-LINE_MESSAGE_EVENT_TYPE = events.MessageEvent
-LINE_TEXT_MESSAGE_EVENT_TYPE = events.TextMessage
+LineMessageEventType = events.MessageEvent
+LineTextMessageEventType = events.TextMessage
 
 # startup FastAPI
 app = FastAPI()
 
 
 # body of echo
-async def echo_body(event: LINE_TEXT_MESSAGE_EVENT_TYPE) -> NoReturn:
+async def echo_body(event: LineTextMessageEventType) -> NoReturn:
     await line_api.reply_message_async(
         event.reply_token,
         TextMessage(text=f"{event.message.text}")
@@ -43,7 +43,7 @@ async def echo_body(event: LINE_TEXT_MESSAGE_EVENT_TYPE) -> NoReturn:
 async def echo(request: Request, background_tasks: BackgroundTasks) -> Response:
     # parse request and get events
     try:
-        request_events: List[LINE_MESSAGE_EVENT_TYPE] = parser.parse(
+        request_events: List[LineMessageEventType] = parser.parse(
             (await request.body()).decode("utf-8"),
             request.headers.get("X-Line-Signature", "")
         )


### PR DESCRIPTION
# 作業内容

- オウム返しをする機能を実装。

# 動作確認時の作業

- 以下の項目を環境変数に追加して下さい。
  - `POETRY_COVID19_REMINDER_LINE_BOT_TOKEN` : LINE BOTの長期トークン
  - `POETRY_COVID19_REMINDER_LINE_CHANNEL_SECRET` : LINE BOTのチャンネルシークレット

# Pull Request 再発行の理由

- 文字列以外のメッセージを受け取った際にエラーを生じるバグの修正のため。
- 無駄な `import` を削除しました。

## 補足

- ngrok を使用して動作確認を行いました。
- `line_api.reply_message_async` が `throw` する可能性のある `Exception` を把握できなかったので、そこだけエラー処理がありません。
- 以下のコミットは `Rebase` 打ちまくっても何故かメッセージに `(#2)` を付けられなかったので、多分ありません。
  - 1572d841124b064ef31cea20bc06ec3c18d9962a
  - 9365c737698e73c69b2fd351e874837e5bbbe94d
- `WebhookParser` がエラーを吐いた時は暫定で `HTTP 503 Error` にしてます

### その他

何度もプルリク作ってマジですみません許してください